### PR TITLE
設定値にgroupを使用しない形に修正

### DIFF
--- a/code/garminSmartLockApi/resources-jpn/strings/strings.xml
+++ b/code/garminSmartLockApi/resources-jpn/strings/strings.xml
@@ -3,149 +3,143 @@
     <string id="AppVersionTitle" scope="foreground">アプリバージョン</string>
 
 
-    <string id="RefreshApiGroup" scope="foreground">表示情報更新の設定</string>
-    <string id="RefreshApiGroupDescription" scope="foreground">表示情報更新に関連する設定項目</string>
+    <string id="RefreshApiGroup" scope="foreground">◆表示情報更新の設定</string>
 
-    <string id="DataUpdateTimeSecGlance" scope="foreground">ウィジェット一覧画面の更新頻度(秒)</string>
-    <string id="DataUpdateTimeSecMain" scope="foreground">アプリ画面の更新頻度(秒)</string>
-    <string id="DataUpdateTimeMovingSecMain" scope="foreground">鍵動作中のアプリ画面の更新頻度(秒)</string>
+    <string id="DataUpdateTimeSecGlance" scope="foreground">-  ウィジェット一覧画面の更新頻度(秒)</string>
+    <string id="DataUpdateTimeSecMain" scope="foreground">-  アプリ画面の更新頻度(秒)</string>
+    <string id="DataUpdateTimeMovingSecMain" scope="foreground">-  鍵動作中のアプリ画面の更新頻度(秒)</string>
 
-    <string id="TimeoutGroup" scope="foreground">タイムアウトの設定</string>
-    <string id="TimeoutGroupDescription" scope="foreground">タイムアウトに関連する設定項目</string>
+    <string id="TimeoutGroup" scope="foreground">◆タイムアウトの設定</string>
 
-    <string id="MovingTimeoutSecProp" scope="foreground">鍵動作中の状態から抜け出す時間(秒)</string>
+    <string id="MovingTimeoutSecProp" scope="foreground">-  鍵動作中の状態から抜け出す時間(秒)</string>
     
 
     <!--API-->
-    <string id="ApiGroup" scope="glance">APIの設定</string>
-    <string id="ApiGroupDescription" scope="glance">APIに関連する設定項目</string>
+    <string id="ApiGroup" scope="glance">◆APIの設定</string>
 
-    <string id="UseApiModeProp" scope="glance">APIの動作モード</string>
+    <string id="UseApiModeProp" scope="glance">-  APIの動作モード</string>
 
     <!--SESAME API-->
-    <string id="SesamiApiGroup" scope="glance">SESAME API使用時の設定</string>
-    <string id="SesamiApiGroupDescription" scope="glance">SESAME APIに関連する設定項目</string>
+    <string id="SesamiApiGroup" scope="glance">◆SESAME API使用時の設定</string>
 
-    <string id="SesamiHistoryName" scope="glance">SESAMEの履歴に表示される端末名</string>
-    <string id="SesamiQRCode" scope="glance">SesamiのQRコードを読み取った際の文字列(権限がマネジャー以上のもの)</string>
-    <string id="SesamiApiKey" scope="glance">SesamiのAPIキー</string>
+    <string id="SesamiHistoryName" scope="glance">-  SESAMEの履歴に表示される端末名</string>
+    <string id="SesamiQRCode" scope="glance">-  SesamiのQRコードを読み取った際の文字列(権限がマネジャー以上のもの)</string>
+    <string id="SesamiApiKey" scope="glance">-  SesamiのAPIキー</string>
 
     <!--カスタムAPI-->
-    <string id="CheckApiGroup" scope="foreground">現在状態取得機能の設定</string>
-    <string id="CheckApiGroupDescription" scope="foreground">現在状態取得機能に関連する設定項目</string>
+    <string id="CheckApiGroup" scope="foreground">◆現在状態取得機能の設定</string>
 
-    <string id="CheckApiUri" scope="foreground">WebAPI呼び出しURI(現在状態取得)</string>
-    <string id="CheckApiMethod" scope="foreground">WebAPIのメソッド(現在状態取得)</string>
-    <string id="CheckApiParamsKey1" scope="foreground">現在状態取得WebAPIのパラメータ1のキー</string>
-    <string id="CheckApiParamsValue1" scope="foreground">現在状態取得WebAPIのパラメータ1の値</string>
-    <string id="CheckApiParamsKey2" scope="foreground">現在状態取得WebAPIのパラメータ2のキー</string>
-    <string id="CheckApiParamsValue2" scope="foreground">現在状態取得WebAPIのパラメータ2の値</string>
-    <string id="CheckApiParamsKey3" scope="foreground">現在状態取得WebAPIのパラメータ3のキー</string>
-    <string id="CheckApiParamsValue3" scope="foreground">現在状態取得WebAPIのパラメータ3の値</string>
-    <string id="CheckApiParamsKey4" scope="foreground">現在状態取得WebAPIのパラメータ4のキー</string>
-    <string id="CheckApiParamsValue4" scope="foreground">現在状態取得WebAPIのパラメータ4の値</string>
-    <string id="CheckApiParamsKey5" scope="foreground">現在状態取得WebAPIのパラメータ5のキー</string>
-    <string id="CheckApiParamsValue5" scope="foreground">現在状態取得WebAPIのパラメータ5の値</string>
+    <string id="CheckApiUri" scope="foreground">-  WebAPI呼び出しURI(現在状態取得)</string>
+    <string id="CheckApiMethod" scope="foreground">-  WebAPIのメソッド(現在状態取得)</string>
+    <string id="CheckApiParamsKey1" scope="foreground">-  現在状態取得WebAPIのパラメータ1のキー</string>
+    <string id="CheckApiParamsValue1" scope="foreground">-  ==&gt;現在状態取得WebAPIのパラメータ1の値</string>
+    <string id="CheckApiParamsKey2" scope="foreground">-  現在状態取得WebAPIのパラメータ2のキー</string>
+    <string id="CheckApiParamsValue2" scope="foreground">-  ==&gt;現在状態取得WebAPIのパラメータ2の値</string>
+    <string id="CheckApiParamsKey3" scope="foreground">-  現在状態取得WebAPIのパラメータ3のキー</string>
+    <string id="CheckApiParamsValue3" scope="foreground">-  ==&gt;現在状態取得WebAPIのパラメータ3の値</string>
+    <string id="CheckApiParamsKey4" scope="foreground">-  現在状態取得WebAPIのパラメータ4のキー</string>
+    <string id="CheckApiParamsValue4" scope="foreground">-  ==&gt;現在状態取得WebAPIのパラメータ4の値</string>
+    <string id="CheckApiParamsKey5" scope="foreground">-  現在状態取得WebAPIのパラメータ5のキー</string>
+    <string id="CheckApiParamsValue5" scope="foreground">-  ==&gt;現在状態取得WebAPIのパラメータ5の値</string>
 
-    <string id="CheckApiHeadersKey1" scope="foreground">現在状態取得WebAPIのヘッダー1のキー</string>
-    <string id="CheckApiHeadersValue1" scope="foreground">現在状態取得WebAPIのヘッダー1の値</string>
-    <string id="CheckApiHeadersKey2" scope="foreground">現在状態取得WebAPIのヘッダー2のキー</string>
-    <string id="CheckApiHeadersValue2" scope="foreground">現在状態取得WebAPIのヘッダー2の値</string>
-    <string id="CheckApiHeadersKey3" scope="foreground">現在状態取得WebAPIのヘッダー3のキー</string>
-    <string id="CheckApiHeadersValue3" scope="foreground">現在状態取得WebAPIのヘッダー3の値</string>
-    <string id="CheckApiHeadersKey4" scope="foreground">現在状態取得WebAPIのヘッダー4のキー</string>
-    <string id="CheckApiHeadersValue4" scope="foreground">現在状態取得WebAPIのヘッダー4の値</string>
-    <string id="CheckApiHeadersKey5" scope="foreground">現在状態取得WebAPIのヘッダー5のキー</string>
-    <string id="CheckApiHeadersValue5" scope="foreground">現在状態取得WebAPIのヘッダー5の値</string>
+    <string id="CheckApiHeadersKey1" scope="foreground">-  現在状態取得WebAPIのヘッダー1のキー</string>
+    <string id="CheckApiHeadersValue1" scope="foreground">-  ==&gt;現在状態取得WebAPIのヘッダー1の値</string>
+    <string id="CheckApiHeadersKey2" scope="foreground">-  現在状態取得WebAPIのヘッダー2のキー</string>
+    <string id="CheckApiHeadersValue2" scope="foreground">-  ==&gt;現在状態取得WebAPIのヘッダー2の値</string>
+    <string id="CheckApiHeadersKey3" scope="foreground">-  現在状態取得WebAPIのヘッダー3のキー</string>
+    <string id="CheckApiHeadersValue3" scope="foreground">-  ==&gt;現在状態取得WebAPIのヘッダー3の値</string>
+    <string id="CheckApiHeadersKey4" scope="foreground">-  現在状態取得WebAPIのヘッダー4のキー</string>
+    <string id="CheckApiHeadersValue4" scope="foreground">-  ==&gt;現在状態取得WebAPIのヘッダー4の値</string>
+    <string id="CheckApiHeadersKey5" scope="foreground">-  現在状態取得WebAPIのヘッダー5のキー</string>
+    <string id="CheckApiHeadersValue5" scope="foreground">-  ==&gt;現在状態取得WebAPIのヘッダー5の値</string>
 
-    <string id="CheckApiParamLockedKey" scope="foreground">現在状態取得WebAPIにて「施錠済」を表すパラメータのキー</string>
-    <string id="CheckApiParamLockedValue" scope="foreground">現在状態取得WebAPIにて「施錠済」を表すパラメータの値</string>
+    <string id="CheckApiParamLockedKey" scope="foreground">-  現在状態取得WebAPIにて「施錠済」を表すパラメータのキー</string>
+    <string id="CheckApiParamLockedValue" scope="foreground">-  ==&gt;現在状態取得WebAPIにて「施錠済」を表すパラメータの値</string>
 
-    <string id="CheckApiParamUnlockedKey" scope="foreground">現在状態取得WebAPIにて「解錠済」を表すパラメータのキー</string>
-    <string id="CheckApiParamUnlockedValue" scope="foreground">現在状態取得WebAPIにて「解錠済」を表すパラメータの値</string>
+    <string id="CheckApiParamUnlockedKey" scope="foreground">-  現在状態取得WebAPIにて「解錠済」を表すパラメータのキー</string>
+    <string id="CheckApiParamUnlockedValue" scope="foreground">-  ==&gt;現在状態取得WebAPIにて「解錠済」を表すパラメータの値</string>
 
-    <string id="CheckApiParamMovingKey" scope="foreground">現在状態取得WebAPIにて「作動中」を表すパラメータのキー</string>
-    <string id="CheckApiParamMovingValue" scope="foreground">現在状態取得WebAPIにて「作動中」を表すパラメータの値</string>
-
-
-    <string id="MoveApiGroup" scope="foreground">鍵の動作設定</string>
-    <string id="MoveApiGroupDescription" scope="foreground">鍵の動作に関連する設定項目</string>
-
-    <string id="MoveMode" scope="foreground">鍵の動作モードを設定する</string>
-
-    <string id="ToggleApiUri" scope="foreground">WebAPI呼び出しURI(トグル動作)</string>
-    <string id="ToggleApiMethod" scope="foreground">WebAPIのメソッド(トグル動作)</string>
-    <string id="ToggleApiParamsKey1" scope="foreground">トグル動作WebAPIのパラメータ1のキー</string>
-    <string id="ToggleApiParamsValue1" scope="foreground">トグル動作WebAPIのパラメータ1の値</string>
-    <string id="ToggleApiParamsKey2" scope="foreground">トグル動作WebAPIのパラメータ2のキー</string>
-    <string id="ToggleApiParamsValue2" scope="foreground">トグル動作WebAPIのパラメータ2の値</string>
-    <string id="ToggleApiParamsKey3" scope="foreground">トグル動作WebAPIのパラメータ3のキー</string>
-    <string id="ToggleApiParamsValue3" scope="foreground">トグル動作WebAPIのパラメータ3の値</string>
-    <string id="ToggleApiParamsKey4" scope="foreground">トグル動作WebAPIのパラメータ4のキー</string>
-    <string id="ToggleApiParamsValue4" scope="foreground">トグル動作WebAPIのパラメータ4の値</string>
-    <string id="ToggleApiParamsKey5" scope="foreground">トグル動作WebAPIのパラメータ5のキー</string>
-    <string id="ToggleApiParamsValue5" scope="foreground">トグル動作WebAPIのパラメータ5の値</string>
-
-    <string id="ToggleApiHeadersKey1" scope="foreground">トグル動作WebAPIのヘッダー1のキー</string>
-    <string id="ToggleApiHeadersValue1" scope="foreground">トグル動作WebAPIのヘッダー1の値</string>
-    <string id="ToggleApiHeadersKey2" scope="foreground">トグル動作WebAPIのヘッダー2のキー</string>
-    <string id="ToggleApiHeadersValue2" scope="foreground">トグル動作WebAPIのヘッダー2の値</string>
-    <string id="ToggleApiHeadersKey3" scope="foreground">トグル動作WebAPIのヘッダー3のキー</string>
-    <string id="ToggleApiHeadersValue3" scope="foreground">トグル動作WebAPIのヘッダー3の値</string>
-    <string id="ToggleApiHeadersKey4" scope="foreground">トグル動作WebAPIのヘッダー4のキー</string>
-    <string id="ToggleApiHeadersValue4" scope="foreground">トグル動作WebAPIのヘッダー4の値</string>
-    <string id="ToggleApiHeadersKey5" scope="foreground">トグル動作WebAPIのヘッダー5のキー</string>
-    <string id="ToggleApiHeadersValue5" scope="foreground">トグル動作WebAPIのヘッダー5の値</string>
+    <string id="CheckApiParamMovingKey" scope="foreground">-  現在状態取得WebAPIにて「作動中」を表すパラメータのキー</string>
+    <string id="CheckApiParamMovingValue" scope="foreground">-  ==&gt;現在状態取得WebAPIにて「作動中」を表すパラメータの値</string>
 
 
-    <string id="LockApiUri" scope="foreground">WebAPI呼び出しURI(施錠動作)</string>
-    <string id="LockApiMethod" scope="foreground">WebAPIのメソッド(施錠動作)</string>
-    <string id="LockApiParamsKey1" scope="foreground">施錠動作WebAPIのパラメータ1のキー</string>
-    <string id="LockApiParamsValue1" scope="foreground">施錠動作WebAPIのパラメータ1の値</string>
-    <string id="LockApiParamsKey2" scope="foreground">施錠動作WebAPIのパラメータ2のキー</string>
-    <string id="LockApiParamsValue2" scope="foreground">施錠動作WebAPIのパラメータ2の値</string>
-    <string id="LockApiParamsKey3" scope="foreground">施錠動作WebAPIのパラメータ3のキー</string>
-    <string id="LockApiParamsValue3" scope="foreground">施錠動作WebAPIのパラメータ3の値</string>
-    <string id="LockApiParamsKey4" scope="foreground">施錠動作WebAPIのパラメータ4のキー</string>
-    <string id="LockApiParamsValue4" scope="foreground">施錠動作WebAPIのパラメータ4の値</string>
-    <string id="LockApiParamsKey5" scope="foreground">施錠動作WebAPIのパラメータ5のキー</string>
-    <string id="LockApiParamsValue5" scope="foreground">施錠動作WebAPIのパラメータ5の値</string>
+    <string id="MoveApiGroup" scope="foreground">◆鍵の動作設定</string>
 
-    <string id="LockApiHeadersKey1" scope="foreground">施錠動作WebAPIのヘッダー1のキー</string>
-    <string id="LockApiHeadersValue1" scope="foreground">施錠動作WebAPIのヘッダー1の値</string>
-    <string id="LockApiHeadersKey2" scope="foreground">施錠動作WebAPIのヘッダー2のキー</string>
-    <string id="LockApiHeadersValue2" scope="foreground">施錠動作WebAPIのヘッダー2の値</string>
-    <string id="LockApiHeadersKey3" scope="foreground">施錠動作WebAPIのヘッダー3のキー</string>
-    <string id="LockApiHeadersValue3" scope="foreground">施錠動作WebAPIのヘッダー3の値</string>
-    <string id="LockApiHeadersKey4" scope="foreground">施錠動作WebAPIのヘッダー4のキー</string>
-    <string id="LockApiHeadersValue4" scope="foreground">施錠動作WebAPIのヘッダー4の値</string>
-    <string id="LockApiHeadersKey5" scope="foreground">施錠動作WebAPIのヘッダー5のキー</string>
-    <string id="LockApiHeadersValue5" scope="foreground">施錠動作WebAPIのヘッダー5の値</string>
+    <string id="MoveMode" scope="foreground">-  鍵の動作モードを設定する</string>
+
+    <string id="ToggleApiUri" scope="foreground">-  WebAPI呼び出しURI(トグル動作)</string>
+    <string id="ToggleApiMethod" scope="foreground">-  WebAPIのメソッド(トグル動作)</string>
+    <string id="ToggleApiParamsKey1" scope="foreground">-  トグル動作WebAPIのパラメータ1のキー</string>
+    <string id="ToggleApiParamsValue1" scope="foreground">-  ==&gt;トグル動作WebAPIのパラメータ1の値</string>
+    <string id="ToggleApiParamsKey2" scope="foreground">-  トグル動作WebAPIのパラメータ2のキー</string>
+    <string id="ToggleApiParamsValue2" scope="foreground">-  ==&gt;トグル動作WebAPIのパラメータ2の値</string>
+    <string id="ToggleApiParamsKey3" scope="foreground">-  トグル動作WebAPIのパラメータ3のキー</string>
+    <string id="ToggleApiParamsValue3" scope="foreground">-  ==&gt;トグル動作WebAPIのパラメータ3の値</string>
+    <string id="ToggleApiParamsKey4" scope="foreground">-  トグル動作WebAPIのパラメータ4のキー</string>
+    <string id="ToggleApiParamsValue4" scope="foreground">-  ==&gt;トグル動作WebAPIのパラメータ4の値</string>
+    <string id="ToggleApiParamsKey5" scope="foreground">-  トグル動作WebAPIのパラメータ5のキー</string>
+    <string id="ToggleApiParamsValue5" scope="foreground">-  ==&gt;トグル動作WebAPIのパラメータ5の値</string>
+
+    <string id="ToggleApiHeadersKey1" scope="foreground">-  トグル動作WebAPIのヘッダー1のキー</string>
+    <string id="ToggleApiHeadersValue1" scope="foreground">-  ==&gt;トグル動作WebAPIのヘッダー1の値</string>
+    <string id="ToggleApiHeadersKey2" scope="foreground">-  トグル動作WebAPIのヘッダー2のキー</string>
+    <string id="ToggleApiHeadersValue2" scope="foreground">-  ==&gt;トグル動作WebAPIのヘッダー2の値</string>
+    <string id="ToggleApiHeadersKey3" scope="foreground">-  トグル動作WebAPIのヘッダー3のキー</string>
+    <string id="ToggleApiHeadersValue3" scope="foreground">-  ==&gt;トグル動作WebAPIのヘッダー3の値</string>
+    <string id="ToggleApiHeadersKey4" scope="foreground">-  トグル動作WebAPIのヘッダー4のキー</string>
+    <string id="ToggleApiHeadersValue4" scope="foreground">-  ==&gt;トグル動作WebAPIのヘッダー4の値</string>
+    <string id="ToggleApiHeadersKey5" scope="foreground">-  トグル動作WebAPIのヘッダー5のキー</string>
+    <string id="ToggleApiHeadersValue5" scope="foreground">-  ==&gt;トグル動作WebAPIのヘッダー5の値</string>
 
 
-    <string id="UnlockApiUri" scope="foreground">WebAPI呼び出しURI(解錠動作)</string>
-    <string id="UnlockApiMethod" scope="foreground">WebAPIのメソッド(解錠動作)</string>
-    <string id="UnlockApiParamsKey1" scope="foreground">解錠動作WebAPIのパラメータ1のキー</string>
-    <string id="UnlockApiParamsValue1" scope="foreground">解錠動作WebAPIのパラメータ1の値</string>
-    <string id="UnlockApiParamsKey2" scope="foreground">解錠動作WebAPIのパラメータ2のキー</string>
-    <string id="UnlockApiParamsValue2" scope="foreground">解錠動作WebAPIのパラメータ2の値</string>
-    <string id="UnlockApiParamsKey3" scope="foreground">解錠動作WebAPIのパラメータ3のキー</string>
-    <string id="UnlockApiParamsValue3" scope="foreground">解錠動作WebAPIのパラメータ3の値</string>
-    <string id="UnlockApiParamsKey4" scope="foreground">解錠動作WebAPIのパラメータ4のキー</string>
-    <string id="UnlockApiParamsValue4" scope="foreground">解錠動作WebAPIのパラメータ4の値</string>
-    <string id="UnlockApiParamsKey5" scope="foreground">解錠動作WebAPIのパラメータ5のキー</string>
-    <string id="UnlockApiParamsValue5" scope="foreground">解錠動作WebAPIのパラメータ5の値</string>
+    <string id="LockApiUri" scope="foreground">-  WebAPI呼び出しURI(施錠動作)</string>
+    <string id="LockApiMethod" scope="foreground">-  WebAPIのメソッド(施錠動作)</string>
+    <string id="LockApiParamsKey1" scope="foreground">-  施錠動作WebAPIのパラメータ1のキー</string>
+    <string id="LockApiParamsValue1" scope="foreground">-  ==&gt;施錠動作WebAPIのパラメータ1の値</string>
+    <string id="LockApiParamsKey2" scope="foreground">-  施錠動作WebAPIのパラメータ2のキー</string>
+    <string id="LockApiParamsValue2" scope="foreground">-  ==&gt;施錠動作WebAPIのパラメータ2の値</string>
+    <string id="LockApiParamsKey3" scope="foreground">-  施錠動作WebAPIのパラメータ3のキー</string>
+    <string id="LockApiParamsValue3" scope="foreground">-  ==&gt;施錠動作WebAPIのパラメータ3の値</string>
+    <string id="LockApiParamsKey4" scope="foreground">-  施錠動作WebAPIのパラメータ4のキー</string>
+    <string id="LockApiParamsValue4" scope="foreground">-  ==&gt;施錠動作WebAPIのパラメータ4の値</string>
+    <string id="LockApiParamsKey5" scope="foreground">-  施錠動作WebAPIのパラメータ5のキー</string>
+    <string id="LockApiParamsValue5" scope="foreground">-  ==&gt;施錠動作WebAPIのパラメータ5の値</string>
+
+    <string id="LockApiHeadersKey1" scope="foreground">-  施錠動作WebAPIのヘッダー1のキー</string>
+    <string id="LockApiHeadersValue1" scope="foreground">-  ==&gt;施錠動作WebAPIのヘッダー1の値</string>
+    <string id="LockApiHeadersKey2" scope="foreground">-  施錠動作WebAPIのヘッダー2のキー</string>
+    <string id="LockApiHeadersValue2" scope="foreground">-  ==&gt;施錠動作WebAPIのヘッダー2の値</string>
+    <string id="LockApiHeadersKey3" scope="foreground">-  施錠動作WebAPIのヘッダー3のキー</string>
+    <string id="LockApiHeadersValue3" scope="foreground">-  ==&gt;施錠動作WebAPIのヘッダー3の値</string>
+    <string id="LockApiHeadersKey4" scope="foreground">-  施錠動作WebAPIのヘッダー4のキー</string>
+    <string id="LockApiHeadersValue4" scope="foreground">-  ==&gt;施錠動作WebAPIのヘッダー4の値</string>
+    <string id="LockApiHeadersKey5" scope="foreground">-  施錠動作WebAPIのヘッダー5のキー</string>
+    <string id="LockApiHeadersValue5" scope="foreground">-  ==&gt;施錠動作WebAPIのヘッダー5の値</string>
+
+
+    <string id="UnlockApiUri" scope="foreground">-  WebAPI呼び出しURI(解錠動作)</string>
+    <string id="UnlockApiMethod" scope="foreground">-  WebAPIのメソッド(解錠動作)</string>
+    <string id="UnlockApiParamsKey1" scope="foreground">-  解錠動作WebAPIのパラメータ1のキー</string>
+    <string id="UnlockApiParamsValue1" scope="foreground">-  ==&gt;解錠動作WebAPIのパラメータ1の値</string>
+    <string id="UnlockApiParamsKey2" scope="foreground">-  解錠動作WebAPIのパラメータ2のキー</string>
+    <string id="UnlockApiParamsValue2" scope="foreground">-  ==&gt;解錠動作WebAPIのパラメータ2の値</string>
+    <string id="UnlockApiParamsKey3" scope="foreground">-  解錠動作WebAPIのパラメータ3のキー</string>
+    <string id="UnlockApiParamsValue3" scope="foreground">-  ==&gt;解錠動作WebAPIのパラメータ3の値</string>
+    <string id="UnlockApiParamsKey4" scope="foreground">-  解錠動作WebAPIのパラメータ4のキー</string>
+    <string id="UnlockApiParamsValue4" scope="foreground">-  ==&gt;解錠動作WebAPIのパラメータ4の値</string>
+    <string id="UnlockApiParamsKey5" scope="foreground">-  解錠動作WebAPIのパラメータ5のキー</string>
+    <string id="UnlockApiParamsValue5" scope="foreground">-  ==&gt;解錠動作WebAPIのパラメータ5の値</string>
     
-    <string id="UnlockApiHeadersKey1" scope="foreground">解錠動作WebAPIのヘッダー1のキー</string>
-    <string id="UnlockApiHeadersValue1" scope="foreground">解錠動作WebAPIのヘッダー1の値</string>
-    <string id="UnlockApiHeadersKey2" scope="foreground">解錠動作WebAPIのヘッダー2のキー</string>
-    <string id="UnlockApiHeadersValue2" scope="foreground">解錠動作WebAPIのヘッダー2の値</string>
-    <string id="UnlockApiHeadersKey3" scope="foreground">解錠動作WebAPIのヘッダー3のキー</string>
-    <string id="UnlockApiHeadersValue3" scope="foreground">解錠動作WebAPIのヘッダー3の値</string>
-    <string id="UnlockApiHeadersKey4" scope="foreground">解錠動作WebAPIのヘッダー4のキー</string>
-    <string id="UnlockApiHeadersValue4" scope="foreground">解錠動作WebAPIのヘッダー4の値</string>
-    <string id="UnlockApiHeadersKey5" scope="foreground">解錠動作WebAPIのヘッダー5のキー</string>
-    <string id="UnlockApiHeadersValue5" scope="foreground">解錠動作WebAPIのヘッダー5の値</string>
+    <string id="UnlockApiHeadersKey1" scope="foreground">-  解錠動作WebAPIのヘッダー1のキー</string>
+    <string id="UnlockApiHeadersValue1" scope="foreground">-  ==&gt;解錠動作WebAPIのヘッダー1の値</string>
+    <string id="UnlockApiHeadersKey2" scope="foreground">-  解錠動作WebAPIのヘッダー2のキー</string>
+    <string id="UnlockApiHeadersValue2" scope="foreground">-  ==&gt;解錠動作WebAPIのヘッダー2の値</string>
+    <string id="UnlockApiHeadersKey3" scope="foreground">-  解錠動作WebAPIのヘッダー3のキー</string>
+    <string id="UnlockApiHeadersValue3" scope="foreground">-  ==&gt;解錠動作WebAPIのヘッダー3の値</string>
+    <string id="UnlockApiHeadersKey4" scope="foreground">-  解錠動作WebAPIのヘッダー4のキー</string>
+    <string id="UnlockApiHeadersValue4" scope="foreground">-  ==&gt;解錠動作WebAPIのヘッダー4の値</string>
+    <string id="UnlockApiHeadersKey5" scope="foreground">-  解錠動作WebAPIのヘッダー5のキー</string>
+    <string id="UnlockApiHeadersValue5" scope="foreground">-  ==&gt;解錠動作WebAPIのヘッダー5の値</string>
 
 
     <!--内部設定値-->

--- a/code/garminSmartLockApi/resources/settings/properties.xml
+++ b/code/garminSmartLockApi/resources/settings/properties.xml
@@ -1,5 +1,13 @@
 <properties>
-    <property id="appVersionProp" type="string">1.0.0</property>
+    <property id="appVersionProp" type="string">1.1.0</property>
+
+    <property id="refreshApiGroupDescription" type="string">-- V V V V V --------------------</property>
+    <property id="timeoutGroupDescription" type="string">-- V V V V V --------------------</property>
+    <property id="apiGroupDescription" type="string">-- V V V V V --------------------</property>
+    <property id="sesamiApiGroupDescription" type="string">-- V V V V V --------------------</property>
+    <property id="checkApiGroupDescription" type="string">-- V V V V V --------------------</property>
+    <property id="moveApiGroupDescription" type="string">-- V V V V V --------------------</property>
+
 
     <property id="dataUpdateTimeSecGlanceProp" type="number">30</property>
     <property id="dataUpdateTimeSecMainProp" type="number">20</property>

--- a/code/garminSmartLockApi/resources/settings/settings.xml
+++ b/code/garminSmartLockApi/resources/settings/settings.xml
@@ -4,365 +4,371 @@
         <settingConfig type="alphaNumeric" readonly="true" />
     </setting>
 
-    <group id="refreshApi" title="@Strings.RefreshApiGroup" description="@Strings.RefreshApiGroupDescription">
-        <setting propertyKey="@Properties.dataUpdateTimeSecGlanceProp" title="@Strings.DataUpdateTimeSecGlance">
-            <settingConfig type="numeric" required="true" />
-        </setting>
-        <setting propertyKey="@Properties.dataUpdateTimeSecMainProp" title="@Strings.DataUpdateTimeSecMain">
-            <settingConfig type="numeric" required="true" />
-        </setting>
-        <setting propertyKey="@Properties.dataUpdateTimeMovingSecMainProp" title="@Strings.DataUpdateTimeMovingSecMain">
-            <settingConfig type="numeric" required="true" />
-        </setting>
-    </group>
+    <setting propertyKey="@Properties.refreshApiGroupDescription" title="@Strings.RefreshApiGroup">
+        <settingConfig type="alphaNumeric" readonly="true" />
+    </setting><!--Group String-->
+    <setting propertyKey="@Properties.dataUpdateTimeSecGlanceProp" title="@Strings.DataUpdateTimeSecGlance">
+        <settingConfig type="numeric" required="true" />
+    </setting>
+    <setting propertyKey="@Properties.dataUpdateTimeSecMainProp" title="@Strings.DataUpdateTimeSecMain">
+        <settingConfig type="numeric" required="true" />
+    </setting>
+    <setting propertyKey="@Properties.dataUpdateTimeMovingSecMainProp" title="@Strings.DataUpdateTimeMovingSecMain">
+        <settingConfig type="numeric" required="true" />
+    </setting>
 
-    <group id="timeout" title="@Strings.TimeoutGroup" description="@Strings.TimeoutGroupDescription">
-        <setting propertyKey="@Properties.movingTimeoutSecProp" title="@Strings.MovingTimeoutSecProp">
-            <settingConfig type="numeric" required="true" />
-        </setting>
-    </group>
+    <setting propertyKey="@Properties.timeoutGroupDescription" title="@Strings.TimeoutGroup">
+        <settingConfig type="alphaNumeric" readonly="true" />
+    </setting><!--Group String-->
+    <setting propertyKey="@Properties.movingTimeoutSecProp" title="@Strings.MovingTimeoutSecProp">
+        <settingConfig type="numeric" required="true" />
+    </setting>
     
     <!--API-->
-    <group id="api" title="@Strings.ApiGroup" description="@Strings.ApiGroupDescription">
-        <setting propertyKey="@Properties.useApiModeProp" title="@Strings.UseApiModeProp">
-            <settingConfig type="list">
-                <listEntry value="0">@Strings.SesamiApi</listEntry>
-                <listEntry value="1">@Strings.CustomApi</listEntry>
-            </settingConfig>
-        </setting>
-    </group>
+    <setting propertyKey="@Properties.apiGroupDescription" title="@Strings.ApiGroup">
+        <settingConfig type="alphaNumeric" readonly="true" />
+    </setting><!--Group String-->
+    <setting propertyKey="@Properties.useApiModeProp" title="@Strings.UseApiModeProp">
+        <settingConfig type="list">
+            <listEntry value="0">@Strings.SesamiApi</listEntry>
+            <listEntry value="1">@Strings.CustomApi</listEntry>
+        </settingConfig>
+    </setting>
 
     <!--SESAME API-->
-    <group id="sesamiApi" title="@Strings.SesamiApiGroup" description="@Strings.SesamiApiGroupDescription">
-        <setting propertyKey="@Properties.sesamiHistoryName" title="@Strings.SesamiHistoryName">
-            <settingConfig type="alphaNumeric" />
-        </setting>
-        <setting propertyKey="@Properties.sesamiQRCode" title="@Strings.SesamiQRCode">
-            <settingConfig type="alphaNumeric" />
-        </setting>
-        <setting propertyKey="@Properties.sesamiApiKey" title="@Strings.SesamiApiKey">
-            <settingConfig type="alphaNumeric" />
-        </setting>
-    </group>
+    <setting propertyKey="@Properties.sesamiApiGroupDescription" title="@Strings.SesamiApiGroup">
+        <settingConfig type="alphaNumeric" readonly="true" />
+    </setting><!--Group String-->
+    <setting propertyKey="@Properties.sesamiHistoryName" title="@Strings.SesamiHistoryName">
+        <settingConfig type="alphaNumeric" />
+    </setting>
+    <setting propertyKey="@Properties.sesamiQRCode" title="@Strings.SesamiQRCode">
+        <settingConfig type="alphaNumeric" />
+    </setting>
+    <setting propertyKey="@Properties.sesamiApiKey" title="@Strings.SesamiApiKey">
+        <settingConfig type="alphaNumeric" />
+    </setting>
 
     <!--カスタムAPI-->
-    <group id="checkApi" title="@Strings.CheckApiGroup" description="@Strings.CheckApiGroupDescription">
-        <setting propertyKey="@Properties.checkApiUriProp" title="@Strings.CheckApiUri">
-            <settingConfig type="url" />
-        </setting>
-        <setting propertyKey="@Properties.checkApiMethodProp" title="@Strings.CheckApiMethod">
-            <settingConfig type="list">
-                <listEntry value="0">@Strings.Get</listEntry>
-                <listEntry value="1">@Strings.Post</listEntry>
-            </settingConfig>
-        </setting>
-        <setting propertyKey="@Properties.checkApiParamsPropKey1" title="@Strings.CheckApiParamsKey1">
-            <settingConfig type="alphaNumeric" />
-        </setting>
-        <setting propertyKey="@Properties.checkApiParamsPropValue1" title="@Strings.CheckApiParamsValue1">
-            <settingConfig type="alphaNumeric" />
-        </setting>
-        <setting propertyKey="@Properties.checkApiParamsPropKey2" title="@Strings.CheckApiParamsKey2">
-            <settingConfig type="alphaNumeric" />
-        </setting>
-        <setting propertyKey="@Properties.checkApiParamsPropValue2" title="@Strings.CheckApiParamsValue2">
-            <settingConfig type="alphaNumeric" />
-        </setting>
-        <setting propertyKey="@Properties.checkApiParamsPropKey3" title="@Strings.CheckApiParamsKey3">
-            <settingConfig type="alphaNumeric" />
-        </setting>
-        <setting propertyKey="@Properties.checkApiParamsPropValue3" title="@Strings.CheckApiParamsValue3">
-            <settingConfig type="alphaNumeric" />
-        </setting>
-        <setting propertyKey="@Properties.checkApiParamsPropKey4" title="@Strings.CheckApiParamsKey4">
-            <settingConfig type="alphaNumeric" />
-        </setting>
-        <setting propertyKey="@Properties.checkApiParamsPropValue4" title="@Strings.CheckApiParamsValue4">
-            <settingConfig type="alphaNumeric" />
-        </setting>
-        <setting propertyKey="@Properties.checkApiParamsPropKey5" title="@Strings.CheckApiParamsKey5">
-            <settingConfig type="alphaNumeric" />
-        </setting>
-        <setting propertyKey="@Properties.checkApiParamsPropValue5" title="@Strings.CheckApiParamsValue5">
-            <settingConfig type="alphaNumeric" />
-        </setting>
+    <setting propertyKey="@Properties.checkApiGroupDescription" title="@Strings.CheckApiGroup">
+        <settingConfig type="alphaNumeric" readonly="true" />
+    </setting><!--Group String-->
+    <setting propertyKey="@Properties.checkApiUriProp" title="@Strings.CheckApiUri">
+        <settingConfig type="url" />
+    </setting>
+    <setting propertyKey="@Properties.checkApiMethodProp" title="@Strings.CheckApiMethod">
+        <settingConfig type="list">
+            <listEntry value="0">@Strings.Get</listEntry>
+            <listEntry value="1">@Strings.Post</listEntry>
+        </settingConfig>
+    </setting>
+    <setting propertyKey="@Properties.checkApiParamsPropKey1" title="@Strings.CheckApiParamsKey1">
+        <settingConfig type="alphaNumeric" />
+    </setting>
+    <setting propertyKey="@Properties.checkApiParamsPropValue1" title="@Strings.CheckApiParamsValue1">
+        <settingConfig type="alphaNumeric" />
+    </setting>
+    <setting propertyKey="@Properties.checkApiParamsPropKey2" title="@Strings.CheckApiParamsKey2">
+        <settingConfig type="alphaNumeric" />
+    </setting>
+    <setting propertyKey="@Properties.checkApiParamsPropValue2" title="@Strings.CheckApiParamsValue2">
+        <settingConfig type="alphaNumeric" />
+    </setting>
+    <setting propertyKey="@Properties.checkApiParamsPropKey3" title="@Strings.CheckApiParamsKey3">
+        <settingConfig type="alphaNumeric" />
+    </setting>
+    <setting propertyKey="@Properties.checkApiParamsPropValue3" title="@Strings.CheckApiParamsValue3">
+        <settingConfig type="alphaNumeric" />
+    </setting>
+    <setting propertyKey="@Properties.checkApiParamsPropKey4" title="@Strings.CheckApiParamsKey4">
+        <settingConfig type="alphaNumeric" />
+    </setting>
+    <setting propertyKey="@Properties.checkApiParamsPropValue4" title="@Strings.CheckApiParamsValue4">
+        <settingConfig type="alphaNumeric" />
+    </setting>
+    <setting propertyKey="@Properties.checkApiParamsPropKey5" title="@Strings.CheckApiParamsKey5">
+        <settingConfig type="alphaNumeric" />
+    </setting>
+    <setting propertyKey="@Properties.checkApiParamsPropValue5" title="@Strings.CheckApiParamsValue5">
+        <settingConfig type="alphaNumeric" />
+    </setting>
 
-        <setting propertyKey="@Properties.checkApiHeadersPropKey1" title="@Strings.CheckApiHeadersKey1">
-            <settingConfig type="alphaNumeric" />
-        </setting>
-        <setting propertyKey="@Properties.checkApiHeadersPropValue1" title="@Strings.CheckApiHeadersValue1">
-            <settingConfig type="alphaNumeric" />
-        </setting>
-        <setting propertyKey="@Properties.checkApiHeadersPropKey2" title="@Strings.CheckApiHeadersKey2">
-            <settingConfig type="alphaNumeric" />
-        </setting>
-        <setting propertyKey="@Properties.checkApiHeadersPropValue2" title="@Strings.CheckApiHeadersValue2">
-            <settingConfig type="alphaNumeric" />
-        </setting>
-        <setting propertyKey="@Properties.checkApiHeadersPropKey3" title="@Strings.CheckApiHeadersKey3">
-            <settingConfig type="alphaNumeric" />
-        </setting>
-        <setting propertyKey="@Properties.checkApiHeadersPropValue3" title="@Strings.CheckApiHeadersValue3">
-            <settingConfig type="alphaNumeric" />
-        </setting>
-        <setting propertyKey="@Properties.checkApiHeadersPropKey4" title="@Strings.CheckApiHeadersKey4">
-            <settingConfig type="alphaNumeric" />
-        </setting>
-        <setting propertyKey="@Properties.checkApiHeadersPropValue4" title="@Strings.CheckApiHeadersValue4">
-            <settingConfig type="alphaNumeric" />
-        </setting>
-        <setting propertyKey="@Properties.checkApiHeadersPropKey5" title="@Strings.CheckApiHeadersKey5">
-            <settingConfig type="alphaNumeric" />
-        </setting>
-        <setting propertyKey="@Properties.checkApiHeadersPropValue5" title="@Strings.CheckApiHeadersValue5">
-            <settingConfig type="alphaNumeric" />
-        </setting>
+    <setting propertyKey="@Properties.checkApiHeadersPropKey1" title="@Strings.CheckApiHeadersKey1">
+        <settingConfig type="alphaNumeric" />
+    </setting>
+    <setting propertyKey="@Properties.checkApiHeadersPropValue1" title="@Strings.CheckApiHeadersValue1">
+        <settingConfig type="alphaNumeric" />
+    </setting>
+    <setting propertyKey="@Properties.checkApiHeadersPropKey2" title="@Strings.CheckApiHeadersKey2">
+        <settingConfig type="alphaNumeric" />
+    </setting>
+    <setting propertyKey="@Properties.checkApiHeadersPropValue2" title="@Strings.CheckApiHeadersValue2">
+        <settingConfig type="alphaNumeric" />
+    </setting>
+    <setting propertyKey="@Properties.checkApiHeadersPropKey3" title="@Strings.CheckApiHeadersKey3">
+        <settingConfig type="alphaNumeric" />
+    </setting>
+    <setting propertyKey="@Properties.checkApiHeadersPropValue3" title="@Strings.CheckApiHeadersValue3">
+        <settingConfig type="alphaNumeric" />
+    </setting>
+    <setting propertyKey="@Properties.checkApiHeadersPropKey4" title="@Strings.CheckApiHeadersKey4">
+        <settingConfig type="alphaNumeric" />
+    </setting>
+    <setting propertyKey="@Properties.checkApiHeadersPropValue4" title="@Strings.CheckApiHeadersValue4">
+        <settingConfig type="alphaNumeric" />
+    </setting>
+    <setting propertyKey="@Properties.checkApiHeadersPropKey5" title="@Strings.CheckApiHeadersKey5">
+        <settingConfig type="alphaNumeric" />
+    </setting>
+    <setting propertyKey="@Properties.checkApiHeadersPropValue5" title="@Strings.CheckApiHeadersValue5">
+        <settingConfig type="alphaNumeric" />
+    </setting>
 
-        <setting propertyKey="@Properties.checkApiParamLockedPropKey" title="@Strings.CheckApiParamLockedKey">
-            <settingConfig type="alphaNumeric" />
-        </setting>
-        <setting propertyKey="@Properties.checkApiParamLockedPropValue" title="@Strings.CheckApiParamLockedValue">
-            <settingConfig type="alphaNumeric" />
-        </setting>
+    <setting propertyKey="@Properties.checkApiParamLockedPropKey" title="@Strings.CheckApiParamLockedKey">
+        <settingConfig type="alphaNumeric" />
+    </setting>
+    <setting propertyKey="@Properties.checkApiParamLockedPropValue" title="@Strings.CheckApiParamLockedValue">
+        <settingConfig type="alphaNumeric" />
+    </setting>
 
-        <setting propertyKey="@Properties.checkApiParamUnlockedPropKey" title="@Strings.CheckApiParamUnlockedKey">
-            <settingConfig type="alphaNumeric" />
-        </setting>
-        <setting propertyKey="@Properties.checkApiParamUnlockedPropValue" title="@Strings.CheckApiParamUnlockedValue">
-            <settingConfig type="alphaNumeric" />
-        </setting>
+    <setting propertyKey="@Properties.checkApiParamUnlockedPropKey" title="@Strings.CheckApiParamUnlockedKey">
+        <settingConfig type="alphaNumeric" />
+    </setting>
+    <setting propertyKey="@Properties.checkApiParamUnlockedPropValue" title="@Strings.CheckApiParamUnlockedValue">
+        <settingConfig type="alphaNumeric" />
+    </setting>
 
-        <setting propertyKey="@Properties.checkApiParamMovingPropKey" title="@Strings.CheckApiParamMovingKey">
-            <settingConfig type="alphaNumeric" />
-        </setting>
-        <setting propertyKey="@Properties.checkApiParamMovingPropValue" title="@Strings.CheckApiParamMovingValue">
-            <settingConfig type="alphaNumeric" />
-        </setting>
-    </group>
-
-
-    <group id="moveApi" title="@Strings.MoveApiGroup" description="@Strings.MoveApiGroupDescription">
-        <setting propertyKey="@Properties.moveModeProp" title="@Strings.MoveMode">
-            <settingConfig type="list">
-                <listEntry value="0">@Strings.Toggle</listEntry>
-                <listEntry value="1">@Strings.LockAndUnlock</listEntry>
-            </settingConfig>
-        </setting>
-
-        <setting propertyKey="@Properties.toggleApiUriProp" title="@Strings.ToggleApiUri">
-            <settingConfig type="url" />
-        </setting>
-        <setting propertyKey="@Properties.toggleApiMethodProp" title="@Strings.ToggleApiMethod">
-            <settingConfig type="list">
-                <listEntry value="0">@Strings.Get</listEntry>
-                <listEntry value="1">@Strings.Post</listEntry>
-            </settingConfig>
-        </setting>
-        <setting propertyKey="@Properties.toggleApiParamsPropKey1" title="@Strings.ToggleApiParamsKey1">
-            <settingConfig type="alphaNumeric" />
-        </setting>
-        <setting propertyKey="@Properties.toggleApiParamsPropValue1" title="@Strings.ToggleApiParamsValue1">
-            <settingConfig type="alphaNumeric" />
-        </setting>
-        <setting propertyKey="@Properties.toggleApiParamsPropKey2" title="@Strings.ToggleApiParamsKey2">
-            <settingConfig type="alphaNumeric" />
-        </setting>
-        <setting propertyKey="@Properties.toggleApiParamsPropValue2" title="@Strings.ToggleApiParamsValue2">
-            <settingConfig type="alphaNumeric" />
-        </setting>
-        <setting propertyKey="@Properties.toggleApiParamsPropKey3" title="@Strings.ToggleApiParamsKey3">
-            <settingConfig type="alphaNumeric" />
-        </setting>
-        <setting propertyKey="@Properties.toggleApiParamsPropValue3" title="@Strings.ToggleApiParamsValue3">
-            <settingConfig type="alphaNumeric" />
-        </setting>
-        <setting propertyKey="@Properties.toggleApiParamsPropKey4" title="@Strings.ToggleApiParamsKey4">
-            <settingConfig type="alphaNumeric" />
-        </setting>
-        <setting propertyKey="@Properties.toggleApiParamsPropValue4" title="@Strings.ToggleApiParamsValue4">
-            <settingConfig type="alphaNumeric" />
-        </setting>
-        <setting propertyKey="@Properties.toggleApiParamsPropKey5" title="@Strings.ToggleApiParamsKey5">
-            <settingConfig type="alphaNumeric" />
-        </setting>
-        <setting propertyKey="@Properties.toggleApiParamsPropValue5" title="@Strings.ToggleApiParamsValue5">
-            <settingConfig type="alphaNumeric" />
-        </setting>
-
-        <setting propertyKey="@Properties.toggleApiHeadersPropKey1" title="@Strings.ToggleApiHeadersKey1">
-            <settingConfig type="alphaNumeric" />
-        </setting>
-        <setting propertyKey="@Properties.toggleApiHeadersPropValue1" title="@Strings.ToggleApiHeadersValue1">
-            <settingConfig type="alphaNumeric" />
-        </setting>
-        <setting propertyKey="@Properties.toggleApiHeadersPropKey2" title="@Strings.ToggleApiHeadersKey2">
-            <settingConfig type="alphaNumeric" />
-        </setting>
-        <setting propertyKey="@Properties.toggleApiHeadersPropValue2" title="@Strings.ToggleApiHeadersValue2">
-            <settingConfig type="alphaNumeric" />
-        </setting>
-        <setting propertyKey="@Properties.toggleApiHeadersPropKey3" title="@Strings.ToggleApiHeadersKey3">
-            <settingConfig type="alphaNumeric" />
-        </setting>
-        <setting propertyKey="@Properties.toggleApiHeadersPropValue3" title="@Strings.ToggleApiHeadersValue3">
-            <settingConfig type="alphaNumeric" />
-        </setting>
-        <setting propertyKey="@Properties.toggleApiHeadersPropKey4" title="@Strings.ToggleApiHeadersKey4">
-            <settingConfig type="alphaNumeric" />
-        </setting>
-        <setting propertyKey="@Properties.toggleApiHeadersPropValue4" title="@Strings.ToggleApiHeadersValue4">
-            <settingConfig type="alphaNumeric" />
-        </setting>
-        <setting propertyKey="@Properties.toggleApiHeadersPropKey5" title="@Strings.ToggleApiHeadersKey5">
-            <settingConfig type="alphaNumeric" />
-        </setting>
-        <setting propertyKey="@Properties.toggleApiHeadersPropValue5" title="@Strings.ToggleApiHeadersValue5">
-            <settingConfig type="alphaNumeric" />
-        </setting>
+    <setting propertyKey="@Properties.checkApiParamMovingPropKey" title="@Strings.CheckApiParamMovingKey">
+        <settingConfig type="alphaNumeric" />
+    </setting>
+    <setting propertyKey="@Properties.checkApiParamMovingPropValue" title="@Strings.CheckApiParamMovingValue">
+        <settingConfig type="alphaNumeric" />
+    </setting>
 
 
-        <setting propertyKey="@Properties.lockApiUriProp" title="@Strings.LockApiUri">
-            <settingConfig type="url" />
-        </setting>
-        <setting propertyKey="@Properties.lockApiMethodProp" title="@Strings.LockApiMethod">
-            <settingConfig type="list">
-                <listEntry value="0">@Strings.Get</listEntry>
-                <listEntry value="1">@Strings.Post</listEntry>
-            </settingConfig>
-        </setting>
-        <setting propertyKey="@Properties.lockApiParamsPropKey1" title="@Strings.LockApiParamsKey1">
-            <settingConfig type="alphaNumeric" />
-        </setting>
-        <setting propertyKey="@Properties.lockApiParamsPropValue1" title="@Strings.LockApiParamsValue1">
-            <settingConfig type="alphaNumeric" />
-        </setting>
-        <setting propertyKey="@Properties.lockApiParamsPropKey2" title="@Strings.LockApiParamsKey2">
-            <settingConfig type="alphaNumeric" />
-        </setting>
-        <setting propertyKey="@Properties.lockApiParamsPropValue2" title="@Strings.LockApiParamsValue2">
-            <settingConfig type="alphaNumeric" />
-        </setting>
-        <setting propertyKey="@Properties.lockApiParamsPropKey3" title="@Strings.LockApiParamsKey3">
-            <settingConfig type="alphaNumeric" />
-        </setting>
-        <setting propertyKey="@Properties.lockApiParamsPropValue3" title="@Strings.LockApiParamsValue3">
-            <settingConfig type="alphaNumeric" />
-        </setting>
-        <setting propertyKey="@Properties.lockApiParamsPropKey4" title="@Strings.LockApiParamsKey4">
-            <settingConfig type="alphaNumeric" />
-        </setting>
-        <setting propertyKey="@Properties.lockApiParamsPropValue4" title="@Strings.LockApiParamsValue4">
-            <settingConfig type="alphaNumeric" />
-        </setting>
-        <setting propertyKey="@Properties.lockApiParamsPropKey5" title="@Strings.LockApiParamsKey5">
-            <settingConfig type="alphaNumeric" />
-        </setting>
-        <setting propertyKey="@Properties.lockApiParamsPropValue5" title="@Strings.LockApiParamsValue5">
-            <settingConfig type="alphaNumeric" />
-        </setting>
+    <setting propertyKey="@Properties.moveApiGroupDescription" title="@Strings.MoveApiGroup">
+        <settingConfig type="alphaNumeric" readonly="true" />
+    </setting><!--Group String-->
+    <setting propertyKey="@Properties.moveModeProp" title="@Strings.MoveMode">
+        <settingConfig type="list">
+            <listEntry value="0">@Strings.Toggle</listEntry>
+            <listEntry value="1">@Strings.LockAndUnlock</listEntry>
+        </settingConfig>
+    </setting>
 
-        <setting propertyKey="@Properties.lockApiHeadersPropKey1" title="@Strings.LockApiHeadersKey1">
-            <settingConfig type="alphaNumeric" />
-        </setting>
-        <setting propertyKey="@Properties.lockApiHeadersPropValue1" title="@Strings.LockApiHeadersValue1">
-            <settingConfig type="alphaNumeric" />
-        </setting>
-        <setting propertyKey="@Properties.lockApiHeadersPropKey2" title="@Strings.LockApiHeadersKey2">
-            <settingConfig type="alphaNumeric" />
-        </setting>
-        <setting propertyKey="@Properties.lockApiHeadersPropValue2" title="@Strings.LockApiHeadersValue2">
-            <settingConfig type="alphaNumeric" />
-        </setting>
-        <setting propertyKey="@Properties.lockApiHeadersPropKey3" title="@Strings.LockApiHeadersKey3">
-            <settingConfig type="alphaNumeric" />
-        </setting>
-        <setting propertyKey="@Properties.lockApiHeadersPropValue3" title="@Strings.LockApiHeadersValue3">
-            <settingConfig type="alphaNumeric" />
-        </setting>
-        <setting propertyKey="@Properties.lockApiHeadersPropKey4" title="@Strings.LockApiHeadersKey4">
-            <settingConfig type="alphaNumeric" />
-        </setting>
-        <setting propertyKey="@Properties.lockApiHeadersPropValue4" title="@Strings.LockApiHeadersValue4">
-            <settingConfig type="alphaNumeric" />
-        </setting>
-        <setting propertyKey="@Properties.lockApiHeadersPropKey5" title="@Strings.LockApiHeadersKey5">
-            <settingConfig type="alphaNumeric" />
-        </setting>
-        <setting propertyKey="@Properties.lockApiHeadersPropValue5" title="@Strings.LockApiHeadersValue5">
-            <settingConfig type="alphaNumeric" />
-        </setting>
+    <setting propertyKey="@Properties.toggleApiUriProp" title="@Strings.ToggleApiUri">
+        <settingConfig type="url" />
+    </setting>
+    <setting propertyKey="@Properties.toggleApiMethodProp" title="@Strings.ToggleApiMethod">
+        <settingConfig type="list">
+            <listEntry value="0">@Strings.Get</listEntry>
+            <listEntry value="1">@Strings.Post</listEntry>
+        </settingConfig>
+    </setting>
+    <setting propertyKey="@Properties.toggleApiParamsPropKey1" title="@Strings.ToggleApiParamsKey1">
+        <settingConfig type="alphaNumeric" />
+    </setting>
+    <setting propertyKey="@Properties.toggleApiParamsPropValue1" title="@Strings.ToggleApiParamsValue1">
+        <settingConfig type="alphaNumeric" />
+    </setting>
+    <setting propertyKey="@Properties.toggleApiParamsPropKey2" title="@Strings.ToggleApiParamsKey2">
+        <settingConfig type="alphaNumeric" />
+    </setting>
+    <setting propertyKey="@Properties.toggleApiParamsPropValue2" title="@Strings.ToggleApiParamsValue2">
+        <settingConfig type="alphaNumeric" />
+    </setting>
+    <setting propertyKey="@Properties.toggleApiParamsPropKey3" title="@Strings.ToggleApiParamsKey3">
+        <settingConfig type="alphaNumeric" />
+    </setting>
+    <setting propertyKey="@Properties.toggleApiParamsPropValue3" title="@Strings.ToggleApiParamsValue3">
+        <settingConfig type="alphaNumeric" />
+    </setting>
+    <setting propertyKey="@Properties.toggleApiParamsPropKey4" title="@Strings.ToggleApiParamsKey4">
+        <settingConfig type="alphaNumeric" />
+    </setting>
+    <setting propertyKey="@Properties.toggleApiParamsPropValue4" title="@Strings.ToggleApiParamsValue4">
+        <settingConfig type="alphaNumeric" />
+    </setting>
+    <setting propertyKey="@Properties.toggleApiParamsPropKey5" title="@Strings.ToggleApiParamsKey5">
+        <settingConfig type="alphaNumeric" />
+    </setting>
+    <setting propertyKey="@Properties.toggleApiParamsPropValue5" title="@Strings.ToggleApiParamsValue5">
+        <settingConfig type="alphaNumeric" />
+    </setting>
+
+    <setting propertyKey="@Properties.toggleApiHeadersPropKey1" title="@Strings.ToggleApiHeadersKey1">
+        <settingConfig type="alphaNumeric" />
+    </setting>
+    <setting propertyKey="@Properties.toggleApiHeadersPropValue1" title="@Strings.ToggleApiHeadersValue1">
+        <settingConfig type="alphaNumeric" />
+    </setting>
+    <setting propertyKey="@Properties.toggleApiHeadersPropKey2" title="@Strings.ToggleApiHeadersKey2">
+        <settingConfig type="alphaNumeric" />
+    </setting>
+    <setting propertyKey="@Properties.toggleApiHeadersPropValue2" title="@Strings.ToggleApiHeadersValue2">
+        <settingConfig type="alphaNumeric" />
+    </setting>
+    <setting propertyKey="@Properties.toggleApiHeadersPropKey3" title="@Strings.ToggleApiHeadersKey3">
+        <settingConfig type="alphaNumeric" />
+    </setting>
+    <setting propertyKey="@Properties.toggleApiHeadersPropValue3" title="@Strings.ToggleApiHeadersValue3">
+        <settingConfig type="alphaNumeric" />
+    </setting>
+    <setting propertyKey="@Properties.toggleApiHeadersPropKey4" title="@Strings.ToggleApiHeadersKey4">
+        <settingConfig type="alphaNumeric" />
+    </setting>
+    <setting propertyKey="@Properties.toggleApiHeadersPropValue4" title="@Strings.ToggleApiHeadersValue4">
+        <settingConfig type="alphaNumeric" />
+    </setting>
+    <setting propertyKey="@Properties.toggleApiHeadersPropKey5" title="@Strings.ToggleApiHeadersKey5">
+        <settingConfig type="alphaNumeric" />
+    </setting>
+    <setting propertyKey="@Properties.toggleApiHeadersPropValue5" title="@Strings.ToggleApiHeadersValue5">
+        <settingConfig type="alphaNumeric" />
+    </setting>
 
 
-        <setting propertyKey="@Properties.unlockApiUriProp" title="@Strings.UnlockApiUri">
-            <settingConfig type="url" />
-        </setting>
-        <setting propertyKey="@Properties.unlockApiMethodProp" title="@Strings.UnlockApiMethod">
-            <settingConfig type="list">
-                <listEntry value="0">@Strings.Get</listEntry>
-                <listEntry value="1">@Strings.Post</listEntry>
-            </settingConfig>
-        </setting>
-        <setting propertyKey="@Properties.unlockApiParamsPropKey1" title="@Strings.UnlockApiParamsKey1">
-            <settingConfig type="alphaNumeric" />
-        </setting>
-        <setting propertyKey="@Properties.unlockApiParamsPropValue1" title="@Strings.UnlockApiParamsValue1">
-            <settingConfig type="alphaNumeric" />
-        </setting>
-        <setting propertyKey="@Properties.unlockApiParamsPropKey2" title="@Strings.UnlockApiParamsKey2">
-            <settingConfig type="alphaNumeric" />
-        </setting>
-        <setting propertyKey="@Properties.unlockApiParamsPropValue2" title="@Strings.UnlockApiParamsValue2">
-            <settingConfig type="alphaNumeric" />
-        </setting>
-        <setting propertyKey="@Properties.unlockApiParamsPropKey3" title="@Strings.UnlockApiParamsKey3">
-            <settingConfig type="alphaNumeric" />
-        </setting>
-        <setting propertyKey="@Properties.unlockApiParamsPropValue3" title="@Strings.UnlockApiParamsValue3">
-            <settingConfig type="alphaNumeric" />
-        </setting>
-        <setting propertyKey="@Properties.unlockApiParamsPropKey4" title="@Strings.UnlockApiParamsKey4">
-            <settingConfig type="alphaNumeric" />
-        </setting>
-        <setting propertyKey="@Properties.unlockApiParamsPropValue4" title="@Strings.UnlockApiParamsValue4">
-            <settingConfig type="alphaNumeric" />
-        </setting>
-        <setting propertyKey="@Properties.unlockApiParamsPropKey5" title="@Strings.UnlockApiParamsKey5">
-            <settingConfig type="alphaNumeric" />
-        </setting>
-        <setting propertyKey="@Properties.unlockApiParamsPropValue5" title="@Strings.UnlockApiParamsValue5">
-            <settingConfig type="alphaNumeric" />
-        </setting>
-        
-        <setting propertyKey="@Properties.unlockApiHeadersPropKey1" title="@Strings.UnlockApiHeadersKey1">
-            <settingConfig type="alphaNumeric" />
-        </setting>
-        <setting propertyKey="@Properties.unlockApiHeadersPropValue1" title="@Strings.UnlockApiHeadersValue1">
-            <settingConfig type="alphaNumeric" />
-        </setting>
-        <setting propertyKey="@Properties.unlockApiHeadersPropKey2" title="@Strings.UnlockApiHeadersKey2">
-            <settingConfig type="alphaNumeric" />
-        </setting>
-        <setting propertyKey="@Properties.unlockApiHeadersPropValue2" title="@Strings.UnlockApiHeadersValue2">
-            <settingConfig type="alphaNumeric" />
-        </setting>
-        <setting propertyKey="@Properties.unlockApiHeadersPropKey3" title="@Strings.UnlockApiHeadersKey3">
-            <settingConfig type="alphaNumeric" />
-        </setting>
-        <setting propertyKey="@Properties.unlockApiHeadersPropValue3" title="@Strings.UnlockApiHeadersValue3">
-            <settingConfig type="alphaNumeric" />
-        </setting>
-        <setting propertyKey="@Properties.unlockApiHeadersPropKey4" title="@Strings.UnlockApiHeadersKey4">
-            <settingConfig type="alphaNumeric" />
-        </setting>
-        <setting propertyKey="@Properties.unlockApiHeadersPropValue4" title="@Strings.UnlockApiHeadersValue4">
-            <settingConfig type="alphaNumeric" />
-        </setting>
-        <setting propertyKey="@Properties.unlockApiHeadersPropKey5" title="@Strings.UnlockApiHeadersKey5">
-            <settingConfig type="alphaNumeric" />
-        </setting>
-        <setting propertyKey="@Properties.unlockApiHeadersPropValue5" title="@Strings.UnlockApiHeadersValue5">
-            <settingConfig type="alphaNumeric" />
-        </setting>
-    </group>
+    <setting propertyKey="@Properties.lockApiUriProp" title="@Strings.LockApiUri">
+        <settingConfig type="url" />
+    </setting>
+    <setting propertyKey="@Properties.lockApiMethodProp" title="@Strings.LockApiMethod">
+        <settingConfig type="list">
+            <listEntry value="0">@Strings.Get</listEntry>
+            <listEntry value="1">@Strings.Post</listEntry>
+        </settingConfig>
+    </setting>
+    <setting propertyKey="@Properties.lockApiParamsPropKey1" title="@Strings.LockApiParamsKey1">
+        <settingConfig type="alphaNumeric" />
+    </setting>
+    <setting propertyKey="@Properties.lockApiParamsPropValue1" title="@Strings.LockApiParamsValue1">
+        <settingConfig type="alphaNumeric" />
+    </setting>
+    <setting propertyKey="@Properties.lockApiParamsPropKey2" title="@Strings.LockApiParamsKey2">
+        <settingConfig type="alphaNumeric" />
+    </setting>
+    <setting propertyKey="@Properties.lockApiParamsPropValue2" title="@Strings.LockApiParamsValue2">
+        <settingConfig type="alphaNumeric" />
+    </setting>
+    <setting propertyKey="@Properties.lockApiParamsPropKey3" title="@Strings.LockApiParamsKey3">
+        <settingConfig type="alphaNumeric" />
+    </setting>
+    <setting propertyKey="@Properties.lockApiParamsPropValue3" title="@Strings.LockApiParamsValue3">
+        <settingConfig type="alphaNumeric" />
+    </setting>
+    <setting propertyKey="@Properties.lockApiParamsPropKey4" title="@Strings.LockApiParamsKey4">
+        <settingConfig type="alphaNumeric" />
+    </setting>
+    <setting propertyKey="@Properties.lockApiParamsPropValue4" title="@Strings.LockApiParamsValue4">
+        <settingConfig type="alphaNumeric" />
+    </setting>
+    <setting propertyKey="@Properties.lockApiParamsPropKey5" title="@Strings.LockApiParamsKey5">
+        <settingConfig type="alphaNumeric" />
+    </setting>
+    <setting propertyKey="@Properties.lockApiParamsPropValue5" title="@Strings.LockApiParamsValue5">
+        <settingConfig type="alphaNumeric" />
+    </setting>
+
+    <setting propertyKey="@Properties.lockApiHeadersPropKey1" title="@Strings.LockApiHeadersKey1">
+        <settingConfig type="alphaNumeric" />
+    </setting>
+    <setting propertyKey="@Properties.lockApiHeadersPropValue1" title="@Strings.LockApiHeadersValue1">
+        <settingConfig type="alphaNumeric" />
+    </setting>
+    <setting propertyKey="@Properties.lockApiHeadersPropKey2" title="@Strings.LockApiHeadersKey2">
+        <settingConfig type="alphaNumeric" />
+    </setting>
+    <setting propertyKey="@Properties.lockApiHeadersPropValue2" title="@Strings.LockApiHeadersValue2">
+        <settingConfig type="alphaNumeric" />
+    </setting>
+    <setting propertyKey="@Properties.lockApiHeadersPropKey3" title="@Strings.LockApiHeadersKey3">
+        <settingConfig type="alphaNumeric" />
+    </setting>
+    <setting propertyKey="@Properties.lockApiHeadersPropValue3" title="@Strings.LockApiHeadersValue3">
+        <settingConfig type="alphaNumeric" />
+    </setting>
+    <setting propertyKey="@Properties.lockApiHeadersPropKey4" title="@Strings.LockApiHeadersKey4">
+        <settingConfig type="alphaNumeric" />
+    </setting>
+    <setting propertyKey="@Properties.lockApiHeadersPropValue4" title="@Strings.LockApiHeadersValue4">
+        <settingConfig type="alphaNumeric" />
+    </setting>
+    <setting propertyKey="@Properties.lockApiHeadersPropKey5" title="@Strings.LockApiHeadersKey5">
+        <settingConfig type="alphaNumeric" />
+    </setting>
+    <setting propertyKey="@Properties.lockApiHeadersPropValue5" title="@Strings.LockApiHeadersValue5">
+        <settingConfig type="alphaNumeric" />
+    </setting>
+
+
+    <setting propertyKey="@Properties.unlockApiUriProp" title="@Strings.UnlockApiUri">
+        <settingConfig type="url" />
+    </setting>
+    <setting propertyKey="@Properties.unlockApiMethodProp" title="@Strings.UnlockApiMethod">
+        <settingConfig type="list">
+            <listEntry value="0">@Strings.Get</listEntry>
+            <listEntry value="1">@Strings.Post</listEntry>
+        </settingConfig>
+    </setting>
+    <setting propertyKey="@Properties.unlockApiParamsPropKey1" title="@Strings.UnlockApiParamsKey1">
+        <settingConfig type="alphaNumeric" />
+    </setting>
+    <setting propertyKey="@Properties.unlockApiParamsPropValue1" title="@Strings.UnlockApiParamsValue1">
+        <settingConfig type="alphaNumeric" />
+    </setting>
+    <setting propertyKey="@Properties.unlockApiParamsPropKey2" title="@Strings.UnlockApiParamsKey2">
+        <settingConfig type="alphaNumeric" />
+    </setting>
+    <setting propertyKey="@Properties.unlockApiParamsPropValue2" title="@Strings.UnlockApiParamsValue2">
+        <settingConfig type="alphaNumeric" />
+    </setting>
+    <setting propertyKey="@Properties.unlockApiParamsPropKey3" title="@Strings.UnlockApiParamsKey3">
+        <settingConfig type="alphaNumeric" />
+    </setting>
+    <setting propertyKey="@Properties.unlockApiParamsPropValue3" title="@Strings.UnlockApiParamsValue3">
+        <settingConfig type="alphaNumeric" />
+    </setting>
+    <setting propertyKey="@Properties.unlockApiParamsPropKey4" title="@Strings.UnlockApiParamsKey4">
+        <settingConfig type="alphaNumeric" />
+    </setting>
+    <setting propertyKey="@Properties.unlockApiParamsPropValue4" title="@Strings.UnlockApiParamsValue4">
+        <settingConfig type="alphaNumeric" />
+    </setting>
+    <setting propertyKey="@Properties.unlockApiParamsPropKey5" title="@Strings.UnlockApiParamsKey5">
+        <settingConfig type="alphaNumeric" />
+    </setting>
+    <setting propertyKey="@Properties.unlockApiParamsPropValue5" title="@Strings.UnlockApiParamsValue5">
+        <settingConfig type="alphaNumeric" />
+    </setting>
+    
+    <setting propertyKey="@Properties.unlockApiHeadersPropKey1" title="@Strings.UnlockApiHeadersKey1">
+        <settingConfig type="alphaNumeric" />
+    </setting>
+    <setting propertyKey="@Properties.unlockApiHeadersPropValue1" title="@Strings.UnlockApiHeadersValue1">
+        <settingConfig type="alphaNumeric" />
+    </setting>
+    <setting propertyKey="@Properties.unlockApiHeadersPropKey2" title="@Strings.UnlockApiHeadersKey2">
+        <settingConfig type="alphaNumeric" />
+    </setting>
+    <setting propertyKey="@Properties.unlockApiHeadersPropValue2" title="@Strings.UnlockApiHeadersValue2">
+        <settingConfig type="alphaNumeric" />
+    </setting>
+    <setting propertyKey="@Properties.unlockApiHeadersPropKey3" title="@Strings.UnlockApiHeadersKey3">
+        <settingConfig type="alphaNumeric" />
+    </setting>
+    <setting propertyKey="@Properties.unlockApiHeadersPropValue3" title="@Strings.UnlockApiHeadersValue3">
+        <settingConfig type="alphaNumeric" />
+    </setting>
+    <setting propertyKey="@Properties.unlockApiHeadersPropKey4" title="@Strings.UnlockApiHeadersKey4">
+        <settingConfig type="alphaNumeric" />
+    </setting>
+    <setting propertyKey="@Properties.unlockApiHeadersPropValue4" title="@Strings.UnlockApiHeadersValue4">
+        <settingConfig type="alphaNumeric" />
+    </setting>
+    <setting propertyKey="@Properties.unlockApiHeadersPropKey5" title="@Strings.UnlockApiHeadersKey5">
+        <settingConfig type="alphaNumeric" />
+    </setting>
+    <setting propertyKey="@Properties.unlockApiHeadersPropValue5" title="@Strings.UnlockApiHeadersValue5">
+        <settingConfig type="alphaNumeric" />
+    </setting>
 
 </settings>

--- a/code/garminSmartLockApi/resources/strings/strings.xml
+++ b/code/garminSmartLockApi/resources/strings/strings.xml
@@ -3,149 +3,143 @@
     <string id="AppVersionTitle" scope="foreground">App Version</string>
 
 
-    <string id="RefreshApiGroup" scope="foreground">Display information update settings.</string>
-    <string id="RefreshApiGroupDescription" scope="foreground">Settings items related to display information update.</string>
+    <string id="RefreshApiGroup" scope="foreground">&lt;*&gt; Display information update settings.</string>
 
-    <string id="DataUpdateTimeSecGlance" scope="foreground">Refresh frequency of the widget list screen.(sec)</string>
-    <string id="DataUpdateTimeSecMain" scope="foreground">Refresh frequency of app screen updates.(sec)</string>
-    <string id="DataUpdateTimeMovingSecMain" scope="foreground">Refresh frequency of app screen updates during key operation.(sec)</string>
+    <string id="DataUpdateTimeSecGlance" scope="foreground">-  Refresh frequency of the widget list screen.(sec)</string>
+    <string id="DataUpdateTimeSecMain" scope="foreground">-  Refresh frequency of app screen updates.(sec)</string>
+    <string id="DataUpdateTimeMovingSecMain" scope="foreground">-  Refresh frequency of app screen updates during key operation.(sec)</string>
 
-    <string id="TimeoutGroup" scope="foreground">Timeout settings.</string>
-    <string id="TimeoutGroupDescription" scope="foreground">Settings items related to timeout.</string>
+    <string id="TimeoutGroup" scope="foreground">&lt;*&gt; Timeout settings.</string>
 
-    <string id="MovingTimeoutSecProp" scope="foreground">Time to get out of the key operation in progress.(sec)</string>
+    <string id="MovingTimeoutSecProp" scope="foreground">-  Time to get out of the key operation in progress.(sec)</string>
     
     
     <!--API-->
-    <string id="ApiGroup" scope="glance">API settings.</string>
-    <string id="ApiGroupDescription" scope="glance">Settings items related to api.</string>
+    <string id="ApiGroup" scope="glance">&lt;*&gt; API settings.</string>
 
-    <string id="UseApiModeProp" scope="glance">API operation mode.</string>
+    <string id="UseApiModeProp" scope="glance">-  API operation mode.</string>
 
     <!--SESAME API-->
-    <string id="SesamiApiGroup" scope="glance">SESAME API settings.</string>
-    <string id="SesamiApiGroupDescription" scope="glance">Settings when using the SESAME API.</string>
+    <string id="SesamiApiGroup" scope="glance">&lt;*&gt; SESAME API settings.</string>
 
-    <string id="SesamiHistoryName" scope="glance">Terminal name displayed in SESAME history.</string>
-    <string id="SesamiQRCode" scope="glance">String when scanning SESAME's QR code.(Authority is manager or above.)</string>
-    <string id="SesamiApiKey" scope="glance">SESAME API Key.</string>
+    <string id="SesamiHistoryName" scope="glance">-  Terminal name displayed in SESAME history.</string>
+    <string id="SesamiQRCode" scope="glance">-  String when scanning SESAME's QR code.(Authority is manager or above.)</string>
+    <string id="SesamiApiKey" scope="glance">-  SESAME API Key.</string>
 
     <!--カスタムAPI-->
-    <string id="CheckApiGroup" scope="foreground">Current status acquisition function settings.</string>
-    <string id="CheckApiGroupDescription" scope="foreground">Settings items related to the current status acquisition function.</string>
+    <string id="CheckApiGroup" scope="foreground">&lt;*&gt; Current status acquisition function settings.</string>
 
-    <string id="CheckApiUri" scope="foreground">WebAPI call URI.(get current status)</string>
-    <string id="CheckApiMethod" scope="foreground">WebAPI method.(get current status)</string>
-    <string id="CheckApiParamsKey1" scope="foreground">Parameter key1 of the current status acquisition WebAPI.</string>
-    <string id="CheckApiParamsValue1" scope="foreground">Parameter value1 of the current status acquisition WebAPI.</string>
-    <string id="CheckApiParamsKey2" scope="foreground">Parameter key2 of the current status acquisition WebAPI.</string>
-    <string id="CheckApiParamsValue2" scope="foreground">Parameter value2 of the current status acquisition WebAPI.</string>
-    <string id="CheckApiParamsKey3" scope="foreground">Parameter key3 of the current status acquisition WebAPI.</string>
-    <string id="CheckApiParamsValue3" scope="foreground">Parameter value3 of the current status acquisition WebAPI.</string>
-    <string id="CheckApiParamsKey4" scope="foreground">Parameter key4 of the current status acquisition WebAPI.</string>
-    <string id="CheckApiParamsValue4" scope="foreground">Parameter value4 of the current status acquisition WebAPI.</string>
-    <string id="CheckApiParamsKey5" scope="foreground">Parameter key5 of the current status acquisition WebAPI.</string>
-    <string id="CheckApiParamsValue5" scope="foreground">Parameter value5 of the current status acquisition WebAPI.</string>
+    <string id="CheckApiUri" scope="foreground">-  WebAPI call URI.(get current status)</string>
+    <string id="CheckApiMethod" scope="foreground">-  WebAPI method.(get current status)</string>
+    <string id="CheckApiParamsKey1" scope="foreground">-  Parameter key1 of the current status acquisition WebAPI.</string>
+    <string id="CheckApiParamsValue1" scope="foreground">-  ==&gt;Parameter value1 of the current status acquisition WebAPI.</string>
+    <string id="CheckApiParamsKey2" scope="foreground">-  Parameter key2 of the current status acquisition WebAPI.</string>
+    <string id="CheckApiParamsValue2" scope="foreground">-  ==&gt;Parameter value2 of the current status acquisition WebAPI.</string>
+    <string id="CheckApiParamsKey3" scope="foreground">-  Parameter key3 of the current status acquisition WebAPI.</string>
+    <string id="CheckApiParamsValue3" scope="foreground">-  ==&gt;Parameter value3 of the current status acquisition WebAPI.</string>
+    <string id="CheckApiParamsKey4" scope="foreground">-  Parameter key4 of the current status acquisition WebAPI.</string>
+    <string id="CheckApiParamsValue4" scope="foreground">-  ==&gt;Parameter value4 of the current status acquisition WebAPI.</string>
+    <string id="CheckApiParamsKey5" scope="foreground">-  Parameter key5 of the current status acquisition WebAPI.</string>
+    <string id="CheckApiParamsValue5" scope="foreground">-  ==&gt;Parameter value5 of the current status acquisition WebAPI.</string>
     
-    <string id="CheckApiHeadersKey1" scope="foreground">Header key1 of the current status acquisition WebAPI.</string>
-    <string id="CheckApiHeadersValue1" scope="foreground">Header value1 of the current status acquisition WebAPI.</string>
-    <string id="CheckApiHeadersKey2" scope="foreground">Header key2 of the current status acquisition WebAPI.</string>
-    <string id="CheckApiHeadersValue2" scope="foreground">Header value2 of the current status acquisition WebAPI.</string>
-    <string id="CheckApiHeadersKey3" scope="foreground">Header key3 of the current status acquisition WebAPI.</string>
-    <string id="CheckApiHeadersValue3" scope="foreground">Header value3 of the current status acquisition WebAPI.</string>
-    <string id="CheckApiHeadersKey4" scope="foreground">Header key4 of the current status acquisition WebAPI.</string>
-    <string id="CheckApiHeadersValue4" scope="foreground">Header value4 of the current status acquisition WebAPI.</string>
-    <string id="CheckApiHeadersKey5" scope="foreground">Header key5 of the current status acquisition WebAPI.</string>
-    <string id="CheckApiHeadersValue5" scope="foreground">Header value5 of the current status acquisition WebAPI.</string>
+    <string id="CheckApiHeadersKey1" scope="foreground">-  Header key1 of the current status acquisition WebAPI.</string>
+    <string id="CheckApiHeadersValue1" scope="foreground">-  ==&gt;Header value1 of the current status acquisition WebAPI.</string>
+    <string id="CheckApiHeadersKey2" scope="foreground">-  Header key2 of the current status acquisition WebAPI.</string>
+    <string id="CheckApiHeadersValue2" scope="foreground">-  ==&gt;Header value2 of the current status acquisition WebAPI.</string>
+    <string id="CheckApiHeadersKey3" scope="foreground">-  Header key3 of the current status acquisition WebAPI.</string>
+    <string id="CheckApiHeadersValue3" scope="foreground">-  ==&gt;Header value3 of the current status acquisition WebAPI.</string>
+    <string id="CheckApiHeadersKey4" scope="foreground">-  Header key4 of the current status acquisition WebAPI.</string>
+    <string id="CheckApiHeadersValue4" scope="foreground">-  ==&gt;Header value4 of the current status acquisition WebAPI.</string>
+    <string id="CheckApiHeadersKey5" scope="foreground">-  Header key5 of the current status acquisition WebAPI.</string>
+    <string id="CheckApiHeadersValue5" scope="foreground">-  ==&gt;Header value5 of the current status acquisition WebAPI.</string>
 
-    <string id="CheckApiParamLockedKey" scope="foreground">Key of parameter indicating "locked" in the current status acquisition WebAPI.</string>
-    <string id="CheckApiParamLockedValue" scope="foreground">Value of parameter indicating "locked" in the current status acquisition WebAPI.</string>
+    <string id="CheckApiParamLockedKey" scope="foreground">-  Key of parameter indicating "locked" in the current status acquisition WebAPI.</string>
+    <string id="CheckApiParamLockedValue" scope="foreground">-  Value of parameter indicating "locked" in the current status acquisition WebAPI.</string>
 
-    <string id="CheckApiParamUnlockedKey" scope="foreground">Key of parameter indicating "unlocked" in the Get Current Status WebAPI.</string>
-    <string id="CheckApiParamUnlockedValue" scope="foreground">Value of parameter indicating "unlocked" in the current status acquisition WebAPI.</string>
+    <string id="CheckApiParamUnlockedKey" scope="foreground">-  Key of parameter indicating "unlocked" in the Get Current Status WebAPI.</string>
+    <string id="CheckApiParamUnlockedValue" scope="foreground">-  Value of parameter indicating "unlocked" in the current status acquisition WebAPI.</string>
 
-    <string id="CheckApiParamMovingKey" scope="foreground">Key of parameter indicating "Moving" in the Get Current Status WebAPI.</string>
-    <string id="CheckApiParamMovingValue" scope="foreground">Value of parameter indicating "Moving" in the current status acquisition WebAPI.</string>
+    <string id="CheckApiParamMovingKey" scope="foreground">-  Key of parameter indicating "Moving" in the Get Current Status WebAPI.</string>
+    <string id="CheckApiParamMovingValue" scope="foreground">-  Value of parameter indicating "Moving" in the current status acquisition WebAPI.</string>
 
 
-    <string id="MoveApiGroup" scope="foreground">Key operation settings.</string>
-    <string id="MoveApiGroupDescription" scope="foreground">Settings items related to key operation.</string>
+    <string id="MoveApiGroup" scope="foreground">&lt;*&gt; Key operation settings.</string>
 
-    <string id="MoveMode" scope="foreground">Setting the key operation mode.</string>
+    <string id="MoveMode" scope="foreground">-  Setting the key operation mode.</string>
 
-    <string id="ToggleApiUri" scope="foreground">WebAPI call URI.(toggle operation)</string>
-    <string id="ToggleApiMethod" scope="foreground">WebAPI method.(toggle operation)</string>
-    <string id="ToggleApiParamsKey1" scope="foreground">Parameter key1 of toggle operation WebAPI.</string>
-    <string id="ToggleApiParamsValue1" scope="foreground">Parameter value1 of toggle operation WebAPI.</string>
-    <string id="ToggleApiParamsKey2" scope="foreground">Parameter key2 of toggle operation WebAPI.</string>
-    <string id="ToggleApiParamsValue2" scope="foreground">Parameter value2 of toggle operation WebAPI.</string>
-    <string id="ToggleApiParamsKey3" scope="foreground">Parameter key3 of toggle operation WebAPI.</string>
-    <string id="ToggleApiParamsValue3" scope="foreground">Parameter value3 of toggle operation WebAPI.</string>
-    <string id="ToggleApiParamsKey4" scope="foreground">Parameter key4 of toggle operation WebAPI.</string>
-    <string id="ToggleApiParamsValue4" scope="foreground">Parameter value4 of toggle operation WebAPI.</string>
-    <string id="ToggleApiParamsKey5" scope="foreground">Parameter key5 of toggle operation WebAPI.</string>
-    <string id="ToggleApiParamsValue5" scope="foreground">Parameter value5 of toggle operation WebAPI.</string>
+    <string id="ToggleApiUri" scope="foreground">-  WebAPI call URI.(toggle operation)</string>
+    <string id="ToggleApiMethod" scope="foreground">-  WebAPI method.(toggle operation)</string>
+    <string id="ToggleApiParamsKey1" scope="foreground">-  Parameter key1 of toggle operation WebAPI.</string>
+    <string id="ToggleApiParamsValue1" scope="foreground">-  ==&gt;Parameter value1 of toggle operation WebAPI.</string>
+    <string id="ToggleApiParamsKey2" scope="foreground">-  Parameter key2 of toggle operation WebAPI.</string>
+    <string id="ToggleApiParamsValue2" scope="foreground">-  ==&gt;Parameter value2 of toggle operation WebAPI.</string>
+    <string id="ToggleApiParamsKey3" scope="foreground">-  Parameter key3 of toggle operation WebAPI.</string>
+    <string id="ToggleApiParamsValue3" scope="foreground">-  ==&gt;Parameter value3 of toggle operation WebAPI.</string>
+    <string id="ToggleApiParamsKey4" scope="foreground">-  Parameter key4 of toggle operation WebAPI.</string>
+    <string id="ToggleApiParamsValue4" scope="foreground">-  ==&gt;Parameter value4 of toggle operation WebAPI.</string>
+    <string id="ToggleApiParamsKey5" scope="foreground">-  Parameter key5 of toggle operation WebAPI.</string>
+    <string id="ToggleApiParamsValue5" scope="foreground">-  ==&gt;Parameter value5 of toggle operation WebAPI.</string>
     
-    <string id="ToggleApiHeadersKey1" scope="foreground">Header key1 of toggle operation WebAPI.</string>
-    <string id="ToggleApiHeadersValue1" scope="foreground">Header value1 of toggle operation WebAPI.</string>
-    <string id="ToggleApiHeadersKey2" scope="foreground">Header key2 of toggle operation WebAPI.</string>
-    <string id="ToggleApiHeadersValue2" scope="foreground">Header value2 of toggle operation WebAPI.</string>
-    <string id="ToggleApiHeadersKey3" scope="foreground">Header key3 of toggle operation WebAPI.</string>
-    <string id="ToggleApiHeadersValue3" scope="foreground">Header value3 of toggle operation WebAPI.</string>
-    <string id="ToggleApiHeadersKey4" scope="foreground">Header key4 of toggle operation WebAPI.</string>
-    <string id="ToggleApiHeadersValue4" scope="foreground">Header value4 of toggle operation WebAPI.</string>
-    <string id="ToggleApiHeadersKey5" scope="foreground">Header key5 of toggle operation WebAPI.</string>
-    <string id="ToggleApiHeadersValue5" scope="foreground">Header value5 of toggle operation WebAPI.</string>
+    <string id="ToggleApiHeadersKey1" scope="foreground">-  Header key1 of toggle operation WebAPI.</string>
+    <string id="ToggleApiHeadersValue1" scope="foreground">-  ==&gt;Header value1 of toggle operation WebAPI.</string>
+    <string id="ToggleApiHeadersKey2" scope="foreground">-  Header key2 of toggle operation WebAPI.</string>
+    <string id="ToggleApiHeadersValue2" scope="foreground">-  ==&gt;Header value2 of toggle operation WebAPI.</string>
+    <string id="ToggleApiHeadersKey3" scope="foreground">-  Header key3 of toggle operation WebAPI.</string>
+    <string id="ToggleApiHeadersValue3" scope="foreground">-  ==&gt;Header value3 of toggle operation WebAPI.</string>
+    <string id="ToggleApiHeadersKey4" scope="foreground">-  Header key4 of toggle operation WebAPI.</string>
+    <string id="ToggleApiHeadersValue4" scope="foreground">-  ==&gt;Header value4 of toggle operation WebAPI.</string>
+    <string id="ToggleApiHeadersKey5" scope="foreground">-  Header key5 of toggle operation WebAPI.</string>
+    <string id="ToggleApiHeadersValue5" scope="foreground">-  ==&gt;Header value5 of toggle operation WebAPI.</string>
 
 
-    <string id="LockApiUri" scope="foreground">WebAPI call URI.(locking operation)</string>
-    <string id="LockApiMethod" scope="foreground">WebAPI method.(locking operation)</string>
-    <string id="LockApiParamsKey1" scope="foreground">Parameter key1 of locking operation WebAPI.</string>
-    <string id="LockApiParamsValue1" scope="foreground">Parameter value1 of locking operation WebAPI.</string>
-    <string id="LockApiParamsKey2" scope="foreground">Parameter key2 of locking operation WebAPI.</string>
-    <string id="LockApiParamsValue2" scope="foreground">Parameter value2 of locking operation WebAPI.</string>
-    <string id="LockApiParamsKey3" scope="foreground">Parameter key3 of locking operation WebAPI.</string>
-    <string id="LockApiParamsValue3" scope="foreground">Parameter value3 of locking operation WebAPI.</string>
-    <string id="LockApiParamsKey4" scope="foreground">Parameter key4 of locking operation WebAPI.</string>
-    <string id="LockApiParamsValue4" scope="foreground">Parameter value4 of locking operation WebAPI.</string>
-    <string id="LockApiParamsKey5" scope="foreground">Parameter key5 of locking operation WebAPI.</string>
-    <string id="LockApiParamsValue5" scope="foreground">Parameter value5 of locking operation WebAPI.</string>
+    <string id="LockApiUri" scope="foreground">-  WebAPI call URI.(locking operation)</string>
+    <string id="LockApiMethod" scope="foreground">-  WebAPI method.(locking operation)</string>
+    <string id="LockApiParamsKey1" scope="foreground">-  Parameter key1 of locking operation WebAPI.</string>
+    <string id="LockApiParamsValue1" scope="foreground">-  ==&gt;Parameter value1 of locking operation WebAPI.</string>
+    <string id="LockApiParamsKey2" scope="foreground">-  Parameter key2 of locking operation WebAPI.</string>
+    <string id="LockApiParamsValue2" scope="foreground">-  ==&gt;Parameter value2 of locking operation WebAPI.</string>
+    <string id="LockApiParamsKey3" scope="foreground">-  Parameter key3 of locking operation WebAPI.</string>
+    <string id="LockApiParamsValue3" scope="foreground">-  ==&gt;Parameter value3 of locking operation WebAPI.</string>
+    <string id="LockApiParamsKey4" scope="foreground">-  Parameter key4 of locking operation WebAPI.</string>
+    <string id="LockApiParamsValue4" scope="foreground">-  ==&gt;Parameter value4 of locking operation WebAPI.</string>
+    <string id="LockApiParamsKey5" scope="foreground">-  Parameter key5 of locking operation WebAPI.</string>
+    <string id="LockApiParamsValue5" scope="foreground">-  ==&gt;Parameter value5 of locking operation WebAPI.</string>
 
-    <string id="LockApiHeadersKey1" scope="foreground">Header key1 of locking operation WebAPI.</string>
-    <string id="LockApiHeadersValue1" scope="foreground">Header value1 of locking operation WebAPI.</string>
-    <string id="LockApiHeadersKey2" scope="foreground">Header key2 of locking operation WebAPI.</string>
-    <string id="LockApiHeadersValue2" scope="foreground">Header value2 of locking operation WebAPI.</string>
-    <string id="LockApiHeadersKey3" scope="foreground">Header key3 of locking operation WebAPI.</string>
-    <string id="LockApiHeadersValue3" scope="foreground">Header value3 of locking operation WebAPI.</string>
-    <string id="LockApiHeadersKey4" scope="foreground">Header key4 of locking operation WebAPI.</string>
-    <string id="LockApiHeadersValue4" scope="foreground">Header value4 of locking operation WebAPI.</string>
-    <string id="LockApiHeadersKey5" scope="foreground">Header key5 of locking operation WebAPI.</string>
-    <string id="LockApiHeadersValue5" scope="foreground">Header value5 of locking operation WebAPI.</string>
+    <string id="LockApiHeadersKey1" scope="foreground">-  Header key1 of locking operation WebAPI.</string>
+    <string id="LockApiHeadersValue1" scope="foreground">-  ==&gt;Header value1 of locking operation WebAPI.</string>
+    <string id="LockApiHeadersKey2" scope="foreground">-  Header key2 of locking operation WebAPI.</string>
+    <string id="LockApiHeadersValue2" scope="foreground">-  ==&gt;Header value2 of locking operation WebAPI.</string>
+    <string id="LockApiHeadersKey3" scope="foreground">-  Header key3 of locking operation WebAPI.</string>
+    <string id="LockApiHeadersValue3" scope="foreground">-  ==&gt;Header value3 of locking operation WebAPI.</string>
+    <string id="LockApiHeadersKey4" scope="foreground">-  Header key4 of locking operation WebAPI.</string>
+    <string id="LockApiHeadersValue4" scope="foreground">-  ==&gt;Header value4 of locking operation WebAPI.</string>
+    <string id="LockApiHeadersKey5" scope="foreground">-  Header key5 of locking operation WebAPI.</string>
+    <string id="LockApiHeadersValue5" scope="foreground">-  ==&gt;Header value5 of locking operation WebAPI.</string>
 
 
-    <string id="UnlockApiUri" scope="foreground">WebAPI call URI.(unlock operation)</string>
-    <string id="UnlockApiMethod" scope="foreground">WebAPI method.(unlock operation)</string>
-    <string id="UnlockApiParamsKey1" scope="foreground">Parameter key1 of unlock operation WebAPI.</string>
-    <string id="UnlockApiParamsValue1" scope="foreground">Parameter value1 of unlock operation WebAPI.</string>
-    <string id="UnlockApiParamsKey2" scope="foreground">Parameter key2 of unlock operation WebAPI.</string>
-    <string id="UnlockApiParamsValue2" scope="foreground">Parameter value2 of unlock operation WebAPI.</string>
-    <string id="UnlockApiParamsKey3" scope="foreground">Parameter key3 of unlock operation WebAPI.</string>
-    <string id="UnlockApiParamsValue3" scope="foreground">Parameter value3 of unlock operation WebAPI.</string>
-    <string id="UnlockApiParamsKey4" scope="foreground">Parameter key4 of unlock operation WebAPI.</string>
-    <string id="UnlockApiParamsValue4" scope="foreground">Parameter value4 of unlock operation WebAPI.</string>
-    <string id="UnlockApiParamsKey5" scope="foreground">Parameter key5 of unlock operation WebAPI.</string>
-    <string id="UnlockApiParamsValue5" scope="foreground">Parameter value5 of unlock operation WebAPI.</string>
+    <string id="UnlockApiUri" scope="foreground">-  WebAPI call URI.(unlock operation)</string>
+    <string id="UnlockApiMethod" scope="foreground">-  WebAPI method.(unlock operation)</string>
+    <string id="UnlockApiParamsKey1" scope="foreground">-  Parameter key1 of unlock operation WebAPI.</string>
+    <string id="UnlockApiParamsValue1" scope="foreground">-  ==&gt;Parameter value1 of unlock operation WebAPI.</string>
+    <string id="UnlockApiParamsKey2" scope="foreground">-  Parameter key2 of unlock operation WebAPI.</string>
+    <string id="UnlockApiParamsValue2" scope="foreground">-  ==&gt;Parameter value2 of unlock operation WebAPI.</string>
+    <string id="UnlockApiParamsKey3" scope="foreground">-  Parameter key3 of unlock operation WebAPI.</string>
+    <string id="UnlockApiParamsValue3" scope="foreground">-  ==&gt;Parameter value3 of unlock operation WebAPI.</string>
+    <string id="UnlockApiParamsKey4" scope="foreground">-  Parameter key4 of unlock operation WebAPI.</string>
+    <string id="UnlockApiParamsValue4" scope="foreground">-  ==&gt;Parameter value4 of unlock operation WebAPI.</string>
+    <string id="UnlockApiParamsKey5" scope="foreground">-  Parameter key5 of unlock operation WebAPI.</string>
+    <string id="UnlockApiParamsValue5" scope="foreground">-  ==&gt;Parameter value5 of unlock operation WebAPI.</string>
     
-    <string id="UnlockApiHeadersKey1" scope="foreground">Header key1 of unlock operation WebAPI.</string>
-    <string id="UnlockApiHeadersValue1" scope="foreground">Header value1 of unlock operation WebAPI.</string>
-    <string id="UnlockApiHeadersKey2" scope="foreground">Header key2 of unlock operation WebAPI.</string>
-    <string id="UnlockApiHeadersValue2" scope="foreground">Header value2 of unlock operation WebAPI.</string>
-    <string id="UnlockApiHeadersKey3" scope="foreground">Header key3 of unlock operation WebAPI.</string>
-    <string id="UnlockApiHeadersValue3" scope="foreground">Header value3 of unlock operation WebAPI.</string>
-    <string id="UnlockApiHeadersKey4" scope="foreground">Header key4 of unlock operation WebAPI.</string>
-    <string id="UnlockApiHeadersValue4" scope="foreground">Header value4 of unlock operation WebAPI.</string>
-    <string id="UnlockApiHeadersKey5" scope="foreground">Header key5 of unlock operation WebAPI.</string>
-    <string id="UnlockApiHeadersValue5" scope="foreground">Header value5 of unlock operation WebAPI.</string>
+    <string id="UnlockApiHeadersKey1" scope="foreground">-  Header key1 of unlock operation WebAPI.</string>
+    <string id="UnlockApiHeadersValue1" scope="foreground">-  ==&gt;Header value1 of unlock operation WebAPI.</string>
+    <string id="UnlockApiHeadersKey2" scope="foreground">-  Header key2 of unlock operation WebAPI.</string>
+    <string id="UnlockApiHeadersValue2" scope="foreground">-  ==&gt;Header value2 of unlock operation WebAPI.</string>
+    <string id="UnlockApiHeadersKey3" scope="foreground">-  Header key3 of unlock operation WebAPI.</string>
+    <string id="UnlockApiHeadersValue3" scope="foreground">-  ==&gt;Header value3 of unlock operation WebAPI.</string>
+    <string id="UnlockApiHeadersKey4" scope="foreground">-  Header key4 of unlock operation WebAPI.</string>
+    <string id="UnlockApiHeadersValue4" scope="foreground">-  ==&gt;Header value4 of unlock operation WebAPI.</string>
+    <string id="UnlockApiHeadersKey5" scope="foreground">-  Header key5 of unlock operation WebAPI.</string>
+    <string id="UnlockApiHeadersValue5" scope="foreground">-  ==&gt;Header value5 of unlock operation WebAPI.</string>
     
 
     <!--内部設定値-->


### PR DESCRIPTION
#1 の対応

同様の現象が報告されています。
2年ほど前から対応されずに放置されているため、この先もfixされる可能性は低いです。
そのため、groupを使用しない形に修正することで対応します。
https://forums.garmin.com/developer/connect-iq/i/bug-reports/connect-iq-ios-cannot-save-group-settings